### PR TITLE
Add Date constructor with a format and date string

### DIFF
--- a/_Deployment/Scripts/SampleJavaBasedTypes/TypeDate.rel
+++ b/_Deployment/Scripts/SampleJavaBasedTypes/TypeDate.rel
@@ -47,6 +47,18 @@ TYPE Date Java FOREIGN
 		d = new java.util.Date(milliseconds.longValue());
 	}
 
+	/** Value constructor.  Construct date given a SimpleDateFormat format and a date string. */
+	public Date(Generator generator, ValueCharacter format, ValueCharacter dateString)  {
+		super(generator);
+		try {
+			d = new java.text.SimpleDateFormat(format.stringValue(),
+							   java.util.Locale.ENGLISH)
+	  			.parse(dateString.stringValue());
+		} catch (java.text.ParseException e) {
+		    e.printStackTrace();
+		}
+	}
+
 	/** Return this Date as a number of milliseconds since the epoch. */
 	public ValueInteger milliseconds(Generator generator) {
 		return ValueInteger.select(generator, d.getTime());


### PR DESCRIPTION
This is a very nice piece of database software.

The following change supports a Date constructor with a format string based on `SimpleDateFormat` and a date string, to return the timestamp. As an example, `Date("yyyy-MM-dd","2005-10-11")` should output `Date(1128981600000)`.

Sincerely, Mark.